### PR TITLE
feat: squash merge auto-improve + fix clawhub publish version

### DIFF
--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -71,10 +71,17 @@ jobs:
       - name: Install ClawHub CLI
         run: npm install -g clawhub
 
+      - name: Extract project version
+        id: version
+        run: |
+          version=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Publish skills to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           CLAWHUB_DISABLE_TELEMETRY: "1"
+          SKILL_VERSION: ${{ steps.version.outputs.version }}
         run: |
           clawhub login --token "$CLAWHUB_TOKEN"
           for skill_dir in skills/*/; do
@@ -83,10 +90,11 @@ jobs:
               echo "SKIP: ${skill_name} has no SKILL.md"
               continue
             fi
-            echo "Publishing skill: ${skill_name}"
-            clawhub publish "${skill_dir}" \
+            echo "Publishing skill: ${skill_name} v${SKILL_VERSION}"
+            clawhub skill publish "${skill_dir}" \
               --slug "${skill_name}" \
               --name "${skill_name}" \
+              --version "${SKILL_VERSION}" \
               --no-input
             echo "Published: ${skill_name}"
           done

--- a/CLEANUP_TODO.md
+++ b/CLEANUP_TODO.md
@@ -87,7 +87,7 @@ rounds or require coordination with the iteration agent.
 
 - [ ] `config.rs`: `from_str_lossy` and `TryFrom<&str>` for `QueueBackendType` have asymmetric match branches — `from_str_lossy` accepts any unknown as Memory, `TryFrom` additionally recognizes `"memory"/"mem"/"in-memory"`; consider aligning or documenting the difference
 - [x] ~~`e2e_test.rs`: 10 `spawn_server*` variants share ~10 lines of boilerplate (registry+state+listener+spawn) — extract a core `start_server(Router) -> String` helper~~ — extracted to `tests/common/mod.rs` with `bind_and_serve()` core helper (e9846ee)
-- [ ] `e2e_test.rs`: `reqwest::Client::new()` repeated 121 times (was 88 before 1d0b78d–392dfeb) — low-impact boilerplate; each test independently creates a client
+- [ ] `e2e_test.rs`: `reqwest::Client::new()` repeated 130 times (was 121 before 157cf8d–64d421c) — low-impact boilerplate; each test independently creates a client
 - [x] ~~`e2e_test.rs`: spawn helpers scattered across file (lines 22-134, 906, 1021, 1160-1211, 1659-1707) — consolidate all spawn helpers at file top~~ — all spawn helpers extracted to `tests/common/mod.rs` (e9846ee)
 - [x] ~~`e2e_test.rs`: `use` statements split between file top (lines 7-19) and mid-file (lines 1578-1582) — move all imports to file top~~ — all `use` statements now at file top (lines 10-24); no mid-file imports (e9846ee)
 
@@ -101,6 +101,9 @@ rounds or require coordination with the iteration agent.
 - [ ] `e2e_graceful_shutdown_waits_for_inflight_task` (line 3088) ≈ `e2e_sqlite_graceful_shutdown_waits_for_inflight_task` (line 3339) — ~95% identical, same pattern
 - [ ] `e2e_batch_async_mixed_providers_and_priorities` (line 4540) ≈ `e2e_sqlite_batch_async_mixed_providers_and_priorities` (line 4677) — ~95% identical, same InMemory vs SQLite pattern
 - [ ] `e2e_batch_async_mock_fail_provider_with_priorities` (line 4864) ≈ `e2e_sqlite_batch_async_mock_fail_provider_with_priorities` (line 4980) — ~95% identical, same pattern
+- [ ] `e2e_batch_async_flaky_with_retry_succeeds` (line 5446) ≈ `e2e_sqlite_batch_async_flaky_with_retry_succeeds` (line 5912) — ~95% identical, same InMemory vs SQLite pattern (added 157cf8d–64d421c)
+- [ ] `e2e_batch_async_flaky_retry_exhausted_fails` (line 5518) ≈ `e2e_sqlite_batch_async_flaky_retry_exhausted_fails` (line 5984) — ~95% identical, same pattern (added 157cf8d–64d421c)
+- [ ] `e2e_batch_async_mixed_retry_policies` (line 5595) ≈ `e2e_sqlite_batch_async_mixed_retry_policies` (line 6060) — ~95% identical, same pattern (added 157cf8d–64d421c)
 - [x] ~~`spawn_server_with_workers_serial` — near-duplicate of `spawn_server_with_workers`~~ — both extracted to `common/mod.rs` with distinct parameters: `spawn_server_with_workers()` (concurrency=2) and `spawn_server_with_workers_serial(extra_providers)` (concurrency=1) (e9846ee)
 
 ## Tests — Cross-Module Deduplication (noti-queue)

--- a/crates/noti-server/tests/common/mod.rs
+++ b/crates/noti-server/tests/common/mod.rs
@@ -541,6 +541,39 @@ pub async fn spawn_server_with_workers_and_rate_limit(
     (base, worker_handle, max_requests)
 }
 
+/// Start a server with in-memory SQLite queue, mock providers, workers, and global rate limiting.
+/// Returns `(base_url, worker_handle, max_requests)`.
+pub async fn spawn_server_sqlite_with_workers_and_rate_limit(
+    extra_providers: Vec<Arc<dyn noti_core::NotifyProvider>>,
+    max_requests: u64,
+    window_secs: u64,
+) -> (String, noti_queue::WorkerHandle, u64) {
+    let mut registry = noti_core::ProviderRegistry::new();
+    registry.register(Arc::new(MockOkProvider));
+    registry.register(Arc::new(MockFailProvider));
+    for p in extra_providers {
+        registry.register(p);
+    }
+
+    let state = sqlite_app_state_with_registry(registry);
+    let worker_config = noti_queue::WorkerConfig::default()
+        .with_concurrency(2)
+        .with_poll_interval(Duration::from_millis(50));
+    let worker_handle = state.start_workers(worker_config);
+
+    let rate_config =
+        RateLimitConfig::new(max_requests, Duration::from_secs(window_secs)).with_per_ip(false);
+    let rate_state = RateLimiterState::new(rate_config);
+
+    let app = noti_server::routes::build_router(state).layer(axum::middleware::from_fn_with_state(
+        rate_state,
+        rate_limit_middleware,
+    ));
+
+    let base = bind_and_serve(app).await;
+    (base, worker_handle, max_requests)
+}
+
 // ───────────────────── Callback server infrastructure ─────────────────────
 
 /// Shared state for the mock callback receiver.

--- a/crates/noti-server/tests/e2e_test.rs
+++ b/crates/noti-server/tests/e2e_test.rs
@@ -15,8 +15,9 @@ use std::time::Duration;
 use common::{
     MockFlakyProvider, MockOkProvider, MockSlowProvider, spawn_callback_server, spawn_server,
     spawn_server_sqlite, spawn_server_sqlite_file, spawn_server_sqlite_file_with_workers,
-    spawn_server_sqlite_with_workers, spawn_server_sqlite_with_workers_serial,
-    spawn_server_with_auth, spawn_server_with_body_limit, spawn_server_with_cors_permissive,
+    spawn_server_sqlite_with_workers, spawn_server_sqlite_with_workers_and_rate_limit,
+    spawn_server_sqlite_with_workers_serial, spawn_server_with_auth,
+    spawn_server_with_body_limit, spawn_server_with_cors_permissive,
     spawn_server_with_cors_restricted, spawn_server_with_full_middleware,
     spawn_server_with_rate_limit, spawn_server_with_rate_limit_per_ip,
     spawn_server_with_request_id, spawn_server_with_workers,
@@ -6147,6 +6148,219 @@ async fn e2e_sqlite_batch_async_mixed_retry_policies() {
             4,
             "SQLite: expected 4 callbacks, got {}",
             received.len()
+        );
+    }
+
+    worker_handle.shutdown_and_join().await;
+}
+
+// ───────────────────── SQLite concurrent batch async with rate limiting ─────────────────────
+
+/// SQLite mirror of `e2e_concurrent_batch_async_with_rate_limit_partial_reject`.
+/// Send multiple concurrent batch requests with rate limiting enabled on SQLite backend.
+/// Some requests should be accepted and some rejected per rate limit quota.
+#[tokio::test]
+async fn e2e_sqlite_concurrent_batch_async_with_rate_limit_partial_reject() {
+    let (callback_base, payloads) = spawn_callback_server().await;
+    // Rate limit: 3 requests per 60s window. We'll send 5 concurrent batch requests.
+    let (base, worker_handle, _max_requests) =
+        spawn_server_sqlite_with_workers_and_rate_limit(vec![], 3, 60).await;
+    let client = reqwest::Client::new();
+    let callback_url = format!("{callback_base}/callback");
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let client = client.clone();
+        let base = base.clone();
+        let cb_url = callback_url.clone();
+        handles.push(tokio::spawn(async move {
+            let resp = client
+                .post(format!("{base}/api/v1/send/async/batch"))
+                .json(&json!({
+                    "items": [
+                        {
+                            "provider": "mock-ok",
+                            "text": format!("sqlite rate-limited batch item {i}"),
+                            "callback_url": &cb_url,
+                        }
+                    ]
+                }))
+                .send()
+                .await
+                .unwrap();
+            resp.status()
+        }));
+    }
+
+    let mut accepted = 0u32;
+    let mut rate_limited = 0u32;
+    for handle in handles {
+        let status = handle.await.unwrap();
+        match status {
+            StatusCode::ACCEPTED => accepted += 1,
+            StatusCode::TOO_MANY_REQUESTS => rate_limited += 1,
+            other => panic!("SQLite: unexpected status: {other}"),
+        }
+    }
+
+    // At most 3 should be accepted (rate limit), at least 2 should be rejected
+    assert!(
+        accepted <= 3,
+        "SQLite: at most 3 requests should pass rate limit, got {accepted}"
+    );
+    assert!(
+        rate_limited >= 2,
+        "SQLite: at least 2 requests should be rate limited, got {rate_limited}"
+    );
+
+    // Wait for accepted tasks to complete
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    {
+        let received = payloads.lock().unwrap();
+        assert_eq!(
+            received.len() as u32,
+            accepted,
+            "SQLite: callbacks should match accepted count: expected {accepted}, got {}",
+            received.len()
+        );
+    }
+
+    worker_handle.shutdown_and_join().await;
+}
+
+/// SQLite mirror of `e2e_batch_async_within_rate_limit_succeeds`.
+/// Rate limited server with SQLite backend: a single batch request within quota should succeed.
+#[tokio::test]
+async fn e2e_sqlite_batch_async_within_rate_limit_succeeds() {
+    let (callback_base, payloads) = spawn_callback_server().await;
+    let (base, worker_handle, _max) =
+        spawn_server_sqlite_with_workers_and_rate_limit(vec![], 10, 60).await;
+    let client = reqwest::Client::new();
+    let callback_url = format!("{callback_base}/callback");
+
+    let resp = client
+        .post(format!("{base}/api/v1/send/async/batch"))
+        .json(&json!({
+            "items": [
+                {
+                    "provider": "mock-ok",
+                    "text": "sqlite rate limited batch 1",
+                    "callback_url": &callback_url,
+                },
+                {
+                    "provider": "mock-ok",
+                    "text": "sqlite rate limited batch 2",
+                    "callback_url": &callback_url,
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["enqueued"], 2);
+    assert_eq!(body["failed"], 0);
+
+    // Verify rate limit headers are present on a separate request
+    let health_resp = client.get(format!("{base}/health")).send().await.unwrap();
+    assert!(health_resp.headers().contains_key("x-ratelimit-limit"));
+
+    let task_ids: Vec<String> = (0..2)
+        .map(|i| body["results"][i]["task_id"].as_str().unwrap().to_string())
+        .collect();
+
+    for tid in &task_ids {
+        let task = wait_for_terminal_status(&client, &base, tid).await;
+        assert_eq!(task["status"], "completed");
+    }
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    {
+        let received = payloads.lock().unwrap();
+        assert_eq!(received.len(), 2);
+    }
+
+    worker_handle.shutdown_and_join().await;
+}
+
+/// SQLite mirror of `e2e_sequential_batch_async_rate_limit_exhaustion`.
+/// Rate limit exhausted mid-sequence on SQLite backend: first batch goes through, second batch gets 429.
+#[tokio::test]
+async fn e2e_sqlite_sequential_batch_async_rate_limit_exhaustion() {
+    let (callback_base, payloads) = spawn_callback_server().await;
+    // Only 2 requests allowed per 60s
+    let (base, worker_handle, _max) =
+        spawn_server_sqlite_with_workers_and_rate_limit(vec![], 2, 60).await;
+    let client = reqwest::Client::new();
+    let callback_url = format!("{callback_base}/callback");
+
+    // First batch — should succeed (request 1)
+    let resp1 = client
+        .post(format!("{base}/api/v1/send/async/batch"))
+        .json(&json!({
+            "items": [
+                {
+                    "provider": "mock-ok",
+                    "text": "sqlite first batch",
+                    "callback_url": &callback_url,
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::ACCEPTED);
+
+    // Second batch — should succeed (request 2)
+    let resp2 = client
+        .post(format!("{base}/api/v1/send/async/batch"))
+        .json(&json!({
+            "items": [
+                {
+                    "provider": "mock-ok",
+                    "text": "sqlite second batch",
+                    "callback_url": &callback_url,
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp2.status(), StatusCode::ACCEPTED);
+
+    // Third batch — should be rate limited (request 3 > quota 2)
+    let resp3 = client
+        .post(format!("{base}/api/v1/send/async/batch"))
+        .json(&json!({
+            "items": [
+                {
+                    "provider": "mock-ok",
+                    "text": "sqlite third batch - should be rejected",
+                    "callback_url": &callback_url,
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp3.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "SQLite: third request should be rate limited"
+    );
+    let body_429: Value = resp3.json().await.unwrap();
+    assert_eq!(body_429["error"], "rate limit exceeded");
+
+    // Wait for the 2 accepted tasks to complete
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    {
+        let received = payloads.lock().unwrap();
+        assert_eq!(
+            received.len(),
+            2,
+            "SQLite: only 2 accepted tasks should produce callbacks"
         );
     }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,7 +19,7 @@ export default defineConfig({
       { text: 'Providers', link: '/providers/overview' },
       { text: 'Reference', link: '/reference/cli' },
       {
-        text: 'v0.1.3',
+        text: 'v0.1.4',
         items: [
           { text: 'Changelog', link: 'https://github.com/loonghao/noti/blob/main/CHANGELOG.md' },
           { text: 'Releases', link: 'https://github.com/loonghao/noti/releases' },


### PR DESCRIPTION
## Summary

Squash merge all `auto-improve` branch incremental changes and fix ClawHub skill publish CI failure.

## Changes

### ClawHub Publish Fix
- Use correct `clawhub skill publish` subcommand (was incorrectly changed to `clawhub publish`)
- Add `--version` parameter with semver version extracted from `.release-please-manifest.json`
- Error was: `--version must be valid semver`

### Auto-improve squash merge
- New e2e tests: SQLite concurrent batch async, rate limiting, retry policy, graceful shutdown, etc.
- Extract shared e2e test helpers into `common/mod.rs`
- Fix VitePress nav version `v0.1.3` → `v0.1.4`
- Update `CLEANUP_TODO.md` counts