### PR TITLE
fix(ci): correct clawhub publish command and improve Docker build robustness

### DIFF
--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -91,7 +91,7 @@ jobs:
               continue
             fi
             echo "Publishing skill: ${skill_name} v${SKILL_VERSION}"
-            clawhub skill publish "${skill_dir}" \
+            clawhub publish "${skill_dir}" \
               --owner "noti-cli" \
               --slug "${skill_name}" \
               --name "${skill_name}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
 WORKDIR /build
 
+# Configure cargo for better CI robustness
+ENV CARGO_NET_RETRY=10 \
+    CARGO_HTTP_TIMEOUT=600
+
 # Copy manifests first for layer caching
 COPY Cargo.toml Cargo.lock ./
 COPY crates/noti-cli/Cargo.toml crates/noti-cli/Cargo.toml
@@ -36,6 +40,7 @@ RUN mkdir -p crates/noti-cli/src && echo "fn main(){}" > crates/noti-cli/src/mai
  && mkdir -p crates/noti-server/src && echo "fn main(){}" > crates/noti-server/src/main.rs
 
 # Build dependencies only (cached unless Cargo.toml/Cargo.lock change)
+# Use || true to allow partial dependency caching; real build will fail explicitly if needed
 RUN case "$TARGETPLATFORM" in \
       "linux/arm64") CARGO_TARGET="--target aarch64-unknown-linux-gnu" ;; \
       *) CARGO_TARGET="" ;; \


### PR DESCRIPTION
## Summary

Fixes two CI/CD failures on \main\ branch:

### Issue 1: ClawHub publish command error
**Error:** \error: unknown command 'publish'\ under \whub skill\

**Root cause:** The workflow (\.github/workflows/generate-skills.yml:94\) uses \clawhub skill publish\, but the CLI was updated to **v0.9.0** which removed the \skill\ subcommand.

**Fix:** Changed \clawhub skill publish\ → \clawhub publish\ (the new canonical command per [clawhub docs](https://docs.openclaw.ai/zh-CN/tools/clawhub)).

### Issue 2: Docker buildx failure (exit code 101)
**Error:** \cargo build --release --bin noti-server --bin noti\ did not complete successfully: exit code: 101

**Root cause:** Rust compilation failure in multi-arch Docker build (linux/amd64 + linux/arm64), likely caused by network timeouts during dependency fetching in CI environment.

**Fix:** Added \CARGO_NET_RETRY=10\ and \CARGO_HTTP_TIMEOUT=600\ environment variables to the Dockerfile builder stage for improved network reliability during CI builds.

## Changes
| File | Change |
|------|--------|
| \.github/workflows/generate-skills.yml\ | \clawhub skill publish\ → \clawhub publish\ |
| \Dockerfile\ | Add \CARGO_NET_RETRY\ and \CARGO_HTTP_TIMEOUT\ env vars |

## Test Plan
- [ ] GitHub Actions \Generate Skills\ workflow runs successfully (publish step)
- [ ] GitHub Actions \Docker\ workflow builds and pushes multi-arch images (amd64 + arm64)