### PR TITLE
fix(ci): fix clawhub publish command and docker arm64 build

### DIFF
--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -91,11 +91,10 @@ jobs:
               continue
             fi
             echo "Publishing skill: ${skill_name} v${SKILL_VERSION}"
-            clawhub publish "${skill_dir}" \
-              --owner "noti-cli" \
+            clawhub skill publish "${skill_dir}" \
               --slug "${skill_name}" \
               --name "${skill_name}" \
               --version "${SKILL_VERSION}" \
-              --no-input
+              --tags latest
             echo "Published: ${skill_name}"
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN case "$TARGETPLATFORM" in \
     esac
 
 # Set the correct Cargo target and linker for cross-compilation
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+    AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
+    PKG_CONFIG_ALLOW_CROSS=1
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

Fixes two CI/CD issues:

### 1. ClawHub publish command error (`generate-skills.yml`)

- **Problem**: `clawhub publish --owner "noti-cli"` fails with `unknown option '--owner'`
- **Root cause**: clawhub CLI v0.9.0 changed the command format. The correct command is `clawhub skill publish` which does not support `--owner` flag.
- **Fix**: 
  - Changed `clawhub publish` → `clawhub skill publish`
  - Removed unsupported `--owner "noti-cli"` parameter
  - Replaced `--no-input` with `--tags latest`

### 2. Docker arm64 build failure exit code 101 (`Dockerfile`)

- **Problem**: Multi-platform Docker build fails on arm64 architecture
- **Root cause**: `rusqlite` uses `bundled` feature (compiles SQLite C source), cross-compilation requires complete environment variable configuration for C toolchain.
- **Fix**: Added necessary cross-compilation environment variables:
  - `CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc`
  - `CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++`
  - `AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar`
  - `PKG_CONFIG_ALLOW_CROSS=1`

## Test Plan

- [ ] Verify ClawHub skill publishing succeeds in CI
- [ ] Verify Docker multi-platform build (linux/amd64, linux/arm64) completes successfully